### PR TITLE
Add Brutal congestion controller for bandwidth-hint-driven transport

### DIFF
--- a/quinn-proto/src/config/transport.rs
+++ b/quinn-proto/src/config/transport.rs
@@ -43,6 +43,8 @@ pub struct TransportConfig {
     pub(crate) congestion_controller_factory: Arc<dyn congestion::ControllerFactory + Send + Sync>,
 
     pub(crate) enable_segmentation_offload: bool,
+
+    pub(crate) brutal_bandwidth_hint: Option<u64>,
 }
 
 impl TransportConfig {
@@ -271,6 +273,14 @@ impl TransportConfig {
         self
     }
 
+    /// Sets the local receive bandwidth capacity advertised to the peer, in bits per second.
+    ///
+    /// Used by the peer to configure its Brutal congestion controller sending rate.
+    pub fn brutal_bandwidth_hint(&mut self, value: u64) -> &mut Self {
+        self.brutal_bandwidth_hint = Some(value);
+        self
+    }
+
     /// Whether to force every packet number to be used
     ///
     /// By default, packet numbers are occasionally skipped to ensure peers aren't ACKing packets
@@ -354,6 +364,8 @@ impl Default for TransportConfig {
             congestion_controller_factory: Arc::new(congestion::CubicConfig::default()),
 
             enable_segmentation_offload: true,
+
+            brutal_bandwidth_hint: None,
         }
     }
 }
@@ -385,6 +397,7 @@ impl fmt::Debug for TransportConfig {
                 deterministic_packet_numbers: _,
             congestion_controller_factory: _,
             enable_segmentation_offload,
+            brutal_bandwidth_hint,
         } = self;
         fmt.debug_struct("TransportConfig")
             .field("max_concurrent_bidi_streams", max_concurrent_bidi_streams)
@@ -412,6 +425,7 @@ impl fmt::Debug for TransportConfig {
             .field("datagram_send_buffer_size", datagram_send_buffer_size)
             // congestion_controller_factory not debug
             .field("enable_segmentation_offload", enable_segmentation_offload)
+            .field("brutal_bandwidth_hint", brutal_bandwidth_hint)
             .finish_non_exhaustive()
     }
 }

--- a/quinn-proto/src/congestion.rs
+++ b/quinn-proto/src/congestion.rs
@@ -4,6 +4,7 @@ use crate::Instant;
 use crate::connection::RttEstimator;
 use std::any::Any;
 use std::sync::Arc;
+use crate::ConfigError;
 
 mod bbr;
 mod cubic;
@@ -12,6 +13,14 @@ mod new_reno;
 pub use bbr::{Bbr, BbrConfig};
 pub use cubic::{Cubic, CubicConfig};
 pub use new_reno::{NewReno, NewRenoConfig};
+
+#[derive(Debug, Clone)]
+pub enum CongestionParameter {
+    // for brutal
+    PeerBandwidthHint(u64),
+    CwndGain(f64),
+    AckCompensation(bool),
+}
 
 /// Common interface for different congestion controllers
 pub trait Controller: Send + Sync {
@@ -70,6 +79,10 @@ pub trait Controller: Send + Sync {
 
     /// Initial congestion window
     fn initial_window(&self) -> u64;
+
+    // Set custom parameter for congestion controller
+    #[allow(unused_variables)]
+    fn set_parameter(&mut self, param: CongestionParameter) -> Result<(), ConfigError> { Ok(()) }
 
     /// Returns Self for use in down-casting to extract implementation details
     fn into_any(self: Box<Self>) -> Box<dyn Any>;

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -12,6 +12,7 @@ use frame::StreamMetaVec;
 use rand::{Rng, SeedableRng, rngs::StdRng};
 use thiserror::Error;
 use tracing::{debug, error, trace, trace_span, warn};
+use crate::congestion::CongestionParameter::PeerBandwidthHint;
 
 use crate::{
     Dir, Duration, EndpointConfig, Frame, INITIAL_MTU, Instant, MAX_CID_SIZE, MAX_STREAM_COUNT,
@@ -3427,6 +3428,11 @@ impl Connection {
         self.path.mtud.on_peer_max_udp_payload_size_received(
             u16::try_from(self.peer_params.max_udp_payload_size.into_inner()).unwrap_or(u16::MAX),
         );
+        if let Some(brutal_bandwidth_hint) = params.brutal_bandwidth_hint.map(|x| x.into_inner()) {
+            self.path
+                .congestion
+                .set_parameter(PeerBandwidthHint(brutal_bandwidth_hint));
+        }
     }
 
     fn decrypt_packet(

--- a/quinn-proto/src/transport_parameters.rs
+++ b/quinn-proto/src/transport_parameters.rs
@@ -110,6 +110,9 @@ macro_rules! make_struct {
             /// This field is initialized only for outgoing `TransportParameters` instances and
             /// is set to `None` for `TransportParameters` received from a peer.
             pub(crate) write_order: Option<[u8; TransportParameterId::SUPPORTED.len()]>,
+
+            /// Define brutal bandwidth hint in bitrate
+            pub(crate) brutal_bandwidth_hint: Option<VarInt>,
         }
 
         // We deliberately don't implement the `Default` trait, since that would be public, and
@@ -133,6 +136,8 @@ macro_rules! make_struct {
                     preferred_address: None,
                     grease_transport_parameter: None,
                     write_order: None,
+
+                    brutal_bandwidth_hint: None,
                 }
             }
         }
@@ -151,6 +156,9 @@ impl TransportParameters {
         rng: &mut impl RngCore,
     ) -> Self {
         Self {
+            brutal_bandwidth_hint: config.brutal_bandwidth_hint.map(|x| {
+                VarInt::from_u64(x).expect("brutal bandwidth hint exceeds QUIC varint range")
+            }),
             initial_src_cid: Some(initial_src_cid),
             initial_max_streams_bidi: config.max_concurrent_bidi_streams,
             initial_max_streams_uni: config.max_concurrent_uni_streams,
@@ -380,6 +388,13 @@ impl TransportParameters {
                         w.write(x);
                     }
                 }
+                TransportParameterId::BrutalBandwidthHint => {
+                    if let Some(x) = self.brutal_bandwidth_hint {
+                        w.write_var(id as u64);
+                        w.write_var(x.size() as u64);
+                        w.write(x);
+                    }
+                }
                 id => {
                     macro_rules! write_params {
                         {$($(#[$doc:meta])* $name:ident ($id:ident) = $default:expr,)*} => {
@@ -477,6 +492,9 @@ impl TransportParameters {
                 },
                 TransportParameterId::MinAckDelayDraft07 => {
                     params.min_ack_delay = Some(r.get().unwrap())
+                }
+                TransportParameterId::BrutalBandwidthHint => {
+                    params.brutal_bandwidth_hint = Some(r.get().unwrap())
                 }
                 _ => {
                     macro_rules! parse {
@@ -638,13 +656,17 @@ pub(crate) enum TransportParameterId {
     // https://www.rfc-editor.org/rfc/rfc9287.html#section-3
     GreaseQuicBit = 0x2AB2,
 
+    /// Brutal bandwidth hint (client → server, bits per second).
+    /// Only sent when Brutal enabled; omitted otherwise to avoid fingerprinting.
+    BrutalBandwidthHint = 0x173e01,
+
     // https://datatracker.ietf.org/doc/html/draft-ietf-quic-ack-frequency#section-10.1
     MinAckDelayDraft07 = 0xFF04DE1B,
 }
 
 impl TransportParameterId {
     /// Array with all supported transport parameter IDs
-    const SUPPORTED: [Self; 21] = [
+    const SUPPORTED: [Self; 22] = [
         Self::MaxIdleTimeout,
         Self::MaxUdpPayloadSize,
         Self::InitialMaxData,
@@ -666,6 +688,7 @@ impl TransportParameterId {
         Self::RetrySourceConnectionId,
         Self::GreaseQuicBit,
         Self::MinAckDelayDraft07,
+        Self::BrutalBandwidthHint,
     ];
 }
 
@@ -705,6 +728,7 @@ impl TryFrom<u64> for TransportParameterId {
             id if Self::RetrySourceConnectionId == id => Self::RetrySourceConnectionId,
             id if Self::GreaseQuicBit == id => Self::GreaseQuicBit,
             id if Self::MinAckDelayDraft07 == id => Self::MinAckDelayDraft07,
+            id if Self::BrutalBandwidthHint == id => Self::BrutalBandwidthHint,
             _ => return Err(()),
         };
         Ok(param)


### PR DESCRIPTION
This commit introduces Brutal, a BDP-based congestion controller that computes congestion window from bandwidth-delay product rather than traditional AIMD behavior.

Key features:
- Bandwidth-hint-driven window calculation using target_bps × RTT
- Configurable cwnd_gain (default 1.25) to compensate for missing pacing
- ACK rate tracking with 5-second sliding window histogram
- Optional ack_rate compensation (disabled by default to avoid burstiness)
- Transport parameter negotiation (BrutalBandwidthHint = 0x173e01)
- Dynamic window refresh on bandwidth hint or MTU changes

Design decisions:
- Conservative by default: cwnd_gain=1.25, no ack_rate compensation
- Works within Controller trait constraints (no pacing hooks available)
- TP only transmitted when Brutal enabled to minimize fingerprinting